### PR TITLE
feat(hubert): Allow confirming combobox input on other keys than ENTER

### DIFF
--- a/apps/webapp/src/article/editor/TagsSelect.tsx
+++ b/apps/webapp/src/article/editor/TagsSelect.tsx
@@ -31,6 +31,7 @@ export const TagsSelect = React.memo(({ value, onChange }: TagsSelectProps) => {
       ))}
       <ComboBox
         fullWidth
+        additionalConfirmChars={[',', ';', '#', ' ']}
         title={'Tag hinzufügen'}
         className={styles.inputWrapper}
         items={availableTags.map((tag) => ({

--- a/libs/hubert/src/form/comboBox/ComboBox.test.tsx
+++ b/libs/hubert/src/form/comboBox/ComboBox.test.tsx
@@ -165,6 +165,25 @@ describe('Combobox', () => {
       });
     });
 
+    it('should call onSelect when typing a key from the "additionalConfirmChars" array', async () => {
+      const user = userEvent.setup();
+      const onSelect = vi.fn();
+
+      const screen = render(
+        <ComboBox
+          title={'Chose something'}
+          items={defaultItems}
+          onSelect={onSelect}
+          additionalConfirmChars={['#']}
+        />
+      );
+
+      await user.type(screen.getByRole('combobox'), 'Apple#');
+      await waitFor(() => {
+        expect(onSelect).toHaveBeenCalledWith('Apple');
+      });
+    });
+
     it('should not call onSelect when the value of an unpropsed item is entered', async () => {
       const user = userEvent.setup();
       const onSelect = vi.fn();


### PR DESCRIPTION
Use new Feature on TagsSelect, splitting on
- ','
- ';'
- '#'
- ' ' (space)

Closes #252 