### PR TITLE
fix(core-api): DB: Make sortkey of usergroup non-nullable

### DIFF
--- a/apps/core-api/lib/lotta/accounts/user_group.ex
+++ b/apps/core-api/lib/lotta/accounts/user_group.ex
@@ -23,9 +23,9 @@ defmodule Lotta.Accounts.UserGroup do
 
   schema "user_groups" do
     field(:name, :string)
-    field(:sort_key, :integer)
-    field(:is_admin_group, :boolean)
-    field(:can_read_full_name, :boolean)
+    field(:sort_key, :integer, default: 0)
+    field(:is_admin_group, :boolean, default: false)
+    field(:can_read_full_name, :boolean, default: false)
 
     field(:enrollment_tokens, {:array, :string}, default: [])
 

--- a/apps/core-api/lib/lotta/tenant_migrations/20240826093644_make_usergroup_can_read_full_name_not_null.ex
+++ b/apps/core-api/lib/lotta/tenant_migrations/20240826093644_make_usergroup_can_read_full_name_not_null.ex
@@ -1,0 +1,32 @@
+defmodule Lotta.Repo.TenantMigrations.MakeUserGroupCanReadFullNameNotNull do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  alias Lotta.Repo
+
+  def up do
+    from(u in "user_groups",
+      where: is_nil(u.can_read_full_name)
+    )
+    |> Repo.update_all([set: [can_read_full_name: false]], prefix: prefix())
+
+    flush()
+
+    alter table(:user_groups) do
+      modify :can_read_full_name, :boolean,
+        null: false,
+        default: false
+    end
+  end
+
+  def down do
+    alter table(:user_groups) do
+      modify :can_read_full_name, :boolean,
+        null: true,
+        default: false
+    end
+  end
+end

--- a/apps/core-api/lib/lotta/tenants/tenant_selector.ex
+++ b/apps/core-api/lib/lotta/tenants/tenant_selector.ex
@@ -95,7 +95,8 @@ defmodule Lotta.Tenants.TenantSelector do
     {20_240_303_164_027, Lotta.Repo.TenantMigrations.AddCanReadFullNameToUserGroups},
     {20_240_711_212_714, Lotta.Repo.TenantMigrations.AddReactionsEnabledToArticle},
     {20_240_712_194_738, Lotta.Repo.TenantMigrations.CreateArticleReactions},
-    {20_240_826_060_632, Lotta.Repo.TenantMigrations.MakeUserGroupIsAdminGroupNotNull}
+    {20_240_826_060_632, Lotta.Repo.TenantMigrations.MakeUserGroupIsAdminGroupNotNull},
+    {20_240_826_093_644, Lotta.Repo.TenantMigrations.MakeUserGroupCanReadFullNameNotNull}
   ]
 
   alias Ecto.Migration.SchemaMigration


### PR DESCRIPTION
Fixes #315 