### PR TITLE
fix(core): Send background push notifications as such for "read_conversation" event

### DIFF
--- a/apps/core-api/lib/lotta/notification/push_notification_request.ex
+++ b/apps/core-api/lib/lotta/notification/push_notification_request.ex
@@ -91,7 +91,7 @@ defmodule Lotta.Notification.PushNotificationRequest do
   @doc since: "4.1.3"
   def create_apns_notification(notification, target) do
     Pigeon.APNS.Notification.new(
-      "",
+      nil,
       target,
       get_topic()
     )
@@ -108,25 +108,16 @@ defmodule Lotta.Notification.PushNotificationRequest do
         |> Pigeon.APNS.Notification.put_sound("default")
       else
         apns_notification
+        |> Map.put(:push_type, :background)
       end
     end)
     |> then(fn apns_notification ->
-      default_data = %{
-        title: notification.title
-      }
-
       if map_size(Map.get(notification, :data)) > 0 do
         apns_notification
         |> Pigeon.APNS.Notification.put_content_available()
-        |> Pigeon.APNS.Notification.put_custom(
-          Map.merge(
-            default_data,
-            notification.data
-          )
-        )
+        |> Pigeon.APNS.Notification.put_custom(notification.data)
       else
         apns_notification
-        |> Pigeon.APNS.Notification.put_custom(default_data)
       end
     end)
     |> Pigeon.APNS.Notification.put_category(notification.category)

--- a/apps/core-api/test/lotta/messages/notification/push_notification_request_test.exs
+++ b/apps/core-api/test/lotta/messages/notification/push_notification_request_test.exs
@@ -43,7 +43,7 @@ defmodule Lotta.Notification.PushNotificationRequestTest do
                device_token: "token",
                payload: %{
                  "aps" => %{
-                   "alert" => "",
+                   "alert" => nil,
                    "category" => "category",
                    "content-available" => 1,
                    "thread-id" => nil


### PR DESCRIPTION
Wie sich rausstellt müssen PushNotifications, die kein "Alert" anzeigen (und vermutlich auch keine Aktion anmelden?) mit dem push_type "background" gesendet werden um von der App verarbeitet zu werden.

Das wäre bei uns beim Nachrichten-Typ "read_conversation" der Fall, der sagt dass ein Nutzer eine Konversation geöffnet hat.

So können in dem Fall zum Beispiel die Push-Nachrichten auf dem Telefon entfernt werden, wenn man sich die Nachrichten im Web ansieht.